### PR TITLE
feat: created RLS policies for delete.

### DIFF
--- a/supabase/migrations/20240605042022_create_rls_delete_policies.sql
+++ b/supabase/migrations/20240605042022_create_rls_delete_policies.sql
@@ -1,0 +1,23 @@
+create policy "Authenticated users can delete their accounts"
+on public."Account" for delete
+to authenticated
+using ( (select auth.uid() as uid) = user_id );
+
+create policy "Authenticated users can delete their saving goals"
+on public."Goal" for delete
+to authenticated
+using ( (select auth.uid() as uid) = user_id );
+
+create policy "Authenticated users can delete their categories"
+on public."Category" for delete
+to authenticated
+using ( (select auth.uid() as uid) = user_id );
+
+create policy "Authenticated users can delete their transactions if they have at least one account"
+on public."Transaction" for delete
+to authenticated
+using ((
+    select exists (
+        select id from public."Account" where (select auth.uid() as uid) = user_id
+    )
+));


### PR DESCRIPTION
* Users can only delete rows in Account, Goal & Category that have matching user id.

* Users can only delete a row in Transaction if they have at least one (financial) account.